### PR TITLE
Organize Functionality into Smaller Files

### DIFF
--- a/src/level.rs
+++ b/src/level.rs
@@ -1,0 +1,70 @@
+use std::fmt::Display;
+use std::str::FromStr;
+use crate::TermColor::{self, *};
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+/// The log level.
+///
+/// This is used to determine which messages are logged. The higher the level,
+/// the more important the message. The order is:
+/// * `Debug`
+/// * `Info`
+/// * `Warn`
+/// * `Error`
+/// * `None`
+///
+/// The `None` level is used to disable logging.
+///
+/// To set the log level, use the `set_level` method on the logger.
+/// ```
+/// use pokey_logger::{Level::Info, LOGGER};
+/// // This will set the log level to `Info`, and not display any debug messages.
+/// LOGGER.set_level(Info);
+/// ```
+pub enum Level {
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+    None = 4
+}
+
+impl Level {
+    /// Returns the [`TermColor`] associated with the level.
+    pub fn get_color(&self) -> TermColor {
+        match self {
+            Level::Debug => Cyan,
+            Level::Info => Green,
+            Level::Warn => Yellow,
+            Level::Error => Red,
+            Level::None => Reset
+        }
+    }
+}
+
+impl Display for Level {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Level::Debug => write!(f, "DEBUG"),
+            Level::Info => write!(f, "INFO"),
+            Level::Warn => write!(f, "WARN"),
+            Level::Error => write!(f, "ERROR"),
+            Level::None => write!(f, "NONE")
+        }
+    }
+}
+
+impl FromStr for Level {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "DEBUG" => Ok(Level::Debug),
+            "INFO" => Ok(Level::Info),
+            "WARN" => Ok(Level::Warn),
+            "ERROR" => Ok(Level::Error),
+            "NONE" => Ok(Level::None),
+            _ => Err(format!("Invalid level: {}", s))
+        }
+    }
+}

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,6 +1,6 @@
+use crate::TermColor::{self, *};
 use std::fmt::Display;
 use std::str::FromStr;
-use crate::TermColor::{self, *};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 /// The log level.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@
 #[cfg(test)]
 mod tests;
 
-mod level;
 mod color;
+mod level;
 mod time;
 #[macro_use]
 pub mod logging_macros;
@@ -117,7 +117,6 @@ pub struct Logger {
     log_path: Mutex<Option<PathBuf>>,
     log_writer: Mutex<Option<BufWriter<File>>>
 }
-
 
 impl Logger {
     /// Create a new Logger instance with all default settings. This never

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //! This is an example of logging some messages. It is assumed that before this
 //! that the `debug!` macro, the `Level` type, and the `LOGGER` constant have been
 //! imported.
+//!
 //! ```rust
 //! use pokey_logger::{Level, LOGGER, debug, warn};
 //!
@@ -51,6 +52,9 @@
 //! as the developer sees fit.
 
 #![allow(dead_code)]
+// Allow needless doctest main function because example above makes more sense
+// with the main function.
+#![allow(clippy::needless_doctest_main)]
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,14 +55,13 @@
 #[cfg(test)]
 mod tests;
 
+mod level;
 mod color;
 mod time;
-use color::{
-    colorize,
-    TermColor::{self, *}
-};
+use color::{colorize, TermColor};
 
 use lazy_static::lazy_static;
+pub use level::Level;
 use std::fmt::Display;
 use std::fs::File;
 use std::io::{prelude::*, BufWriter};
@@ -148,72 +147,6 @@ pub struct Logger {
     log_writer: Mutex<Option<BufWriter<File>>>
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
-/// The log level.
-///
-/// This is used to determine which messages are logged. The higher the level,
-/// the more important the message. The order is:
-/// * `Debug`
-/// * `Info`
-/// * `Warn`
-/// * `Error`
-/// * `None`
-///
-/// The `None` level is used to disable logging.
-///
-/// To set the log level, use the `set_level` method on the logger.
-/// ```
-/// use pokey_logger::{Level::Info, LOGGER};
-/// // This will set the log level to `Info`, and not display any debug messages.
-/// LOGGER.set_level(Info);
-/// ```
-pub enum Level {
-    Debug = 0,
-    Info = 1,
-    Warn = 2,
-    Error = 3,
-    None = 4
-}
-
-impl Level {
-    /// Returns the [`TermColor`] associated with the level.
-    fn get_color(&self) -> TermColor {
-        match self {
-            Level::Debug => Cyan,
-            Level::Info => Green,
-            Level::Warn => Yellow,
-            Level::Error => Red,
-            Level::None => Reset
-        }
-    }
-}
-
-impl Display for Level {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Level::Debug => write!(f, "DEBUG"),
-            Level::Info => write!(f, "INFO"),
-            Level::Warn => write!(f, "WARN"),
-            Level::Error => write!(f, "ERROR"),
-            Level::None => write!(f, "NONE")
-        }
-    }
-}
-
-impl FromStr for Level {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_uppercase().as_str() {
-            "DEBUG" => Ok(Level::Debug),
-            "INFO" => Ok(Level::Info),
-            "WARN" => Ok(Level::Warn),
-            "ERROR" => Ok(Level::Error),
-            "NONE" => Ok(Level::None),
-            _ => Err(format!("Invalid level: {}", s))
-        }
-    }
-}
 
 impl Logger {
     /// Create a new Logger instance with all default settings. This never

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,9 @@ mod tests;
 mod level;
 mod color;
 mod time;
+#[macro_use]
+pub mod logging_macros;
+
 use color::{colorize, TermColor};
 
 use lazy_static::lazy_static;
@@ -74,38 +77,6 @@ lazy_static!(
     /// The global logger.
     pub static ref LOGGER: Logger = Logger::new();
 );
-
-#[macro_export]
-/// Logs a debug message on the global logger.
-macro_rules! debug {
-    ($($arg:tt)*) => {
-        $crate::LOGGER.debug(&format!($($arg)*));
-    }
-}
-
-#[macro_export]
-/// Logs an info message on the global logger.
-macro_rules! info {
-    ($($arg:tt)*) => {
-        $crate::LOGGER.info(&format!($($arg)*));
-    }
-}
-
-#[macro_export]
-/// Logs a warning message on the global logger.
-macro_rules! warn {
-    ($($arg:tt)*) => {
-        $crate::LOGGER.warn(&format!($($arg)*));
-    }
-}
-
-#[macro_export]
-/// Logs an error message on the global logger.
-macro_rules! error {
-    ($($arg:tt)*) => {
-        $crate::LOGGER.error(&format!($($arg)*));
-    }
-}
 
 // TODO: Scoped references that are basically references for certain files and
 //       store the scope name and point to the logger. Then in that scope

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,11 +69,11 @@ use color::{colorize, TermColor};
 
 use lazy_static::lazy_static;
 pub use level::Level;
-use std::fmt::Display;
+
 use std::fs::File;
 use std::io::{prelude::*, BufWriter};
 use std::path::PathBuf;
-use std::str::FromStr;
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 

--- a/src/logging_macros.rs
+++ b/src/logging_macros.rs
@@ -29,4 +29,3 @@ macro_rules! error {
         $crate::LOGGER.error(&format!($($arg)*));
     }
 }
-

--- a/src/logging_macros.rs
+++ b/src/logging_macros.rs
@@ -1,0 +1,32 @@
+#[macro_export]
+/// Logs a debug message on the global logger.
+macro_rules! debug {
+    ($($arg:tt)*) => {
+        $crate::LOGGER.debug(&format!($($arg)*));
+    }
+}
+
+#[macro_export]
+/// Logs an info message on the global logger.
+macro_rules! info {
+    ($($arg:tt)*) => {
+        $crate::LOGGER.info(&format!($($arg)*));
+    }
+}
+
+#[macro_export]
+/// Logs a warning message on the global logger.
+macro_rules! warn {
+    ($($arg:tt)*) => {
+        $crate::LOGGER.warn(&format!($($arg)*));
+    }
+}
+
+#[macro_export]
+/// Logs an error message on the global logger.
+macro_rules! error {
+    ($($arg:tt)*) => {
+        $crate::LOGGER.error(&format!($($arg)*));
+    }
+}
+

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,13 +20,7 @@ fn test_get_and_set_colour() {
     LOGGER.set_color(false);
     assert!(!LOGGER.get_color());
 
-    set_color(true);
-    assert!(LOGGER.get_color());
-    set_color(false);
-    assert!(!LOGGER.get_color());
-
-    // reset to default
-    set_color(true);
+    LOGGER.set_color(true);
 }
 
 #[test]
@@ -54,15 +48,6 @@ fn test_get_and_set_level() {
     assert_eq!(LOGGER.get_level(), Level::Error);
     LOGGER.set_level(Level::None);
     assert_eq!(LOGGER.get_level(), Level::None);
-
-    set_level(Level::Debug);
-    assert_eq!(LOGGER.get_level(), Level::Debug);
-    set_level(Level::Info);
-    assert_eq!(LOGGER.get_level(), Level::Info);
-    set_level(Level::Warn);
-    assert_eq!(LOGGER.get_level(), Level::Warn);
-    set_level(Level::Error);
-    assert_eq!(LOGGER.get_level(), Level::Error);
 
     // Reset the level to the default so that other tests actually log
     // DO NOT REMOVE THIS LINE or you will have problems

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::str::FromStr;
 
 #[test]
 fn test_that_macro_use_compiles() {


### PR DESCRIPTION
The general idea of this PR is to move things into more files so that there isn't a massive 500 line `lib.rs` file.
