### PR TITLE
Don't Color Log Files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,11 +63,12 @@ pub mod logging_macros;
 pub mod color;
 pub mod time;
 
-mod log_message;
 mod level; // not public because level is reexported
+mod log_message;
 
 pub use level::Level;
 
+use crate::log_message::LogMessage;
 use color::TermColor;
 use lazy_static::lazy_static;
 use std::fs::File;
@@ -75,7 +76,6 @@ use std::io::{prelude::*, BufWriter};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
-use crate::log_message::LogMessage;
 
 lazy_static!(
     /// The global logger.
@@ -290,8 +290,7 @@ impl Logger {
         self.set_log_writer_if_not_set();
         if let Ok(ref mut log_writer) = self.log_writer.lock() {
             if log_writer.is_some() {
-                let formatted_message = log_message
-                    .formatted(self.get_log_file_color());
+                let formatted_message = log_message.formatted(self.get_log_file_color());
                 if let Err(e) = log_writer
                     .as_mut()
                     .unwrap()

--- a/src/log_message.rs
+++ b/src/log_message.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use crate::{Level, TermColor};
 
 /// A message to log. It is basically a wrapper around format calls so that

--- a/src/log_message.rs
+++ b/src/log_message.rs
@@ -1,0 +1,67 @@
+use crate::{Level, TermColor};
+
+/// A message to log. It is basically a wrapper around format calls so that
+/// format is only called as needed. For example, if we are logging the colored
+/// message to the terminal and the uncolored message to the file, we will have
+/// to calculate both. If we are logging the uncolored message to both, then
+/// we don't want to calculate the colored message. So this essentially stores
+/// the information needed to format the message, and then only formats it when
+/// needed.
+pub struct LogMessage {
+    colorized: Option<String>,
+    non_colorized: Option<String>,
+    prefix: String,
+    level_string: String,
+    level_color: TermColor,
+    message: String
+}
+
+impl LogMessage {
+    pub fn new(prefix: &str, message: &str, level: Level) -> LogMessage {
+        LogMessage {
+            colorized: None,
+            non_colorized: None,
+            prefix: prefix.to_string(),
+            level_string:  format!("[{}]", level),
+            level_color: level.get_color(),
+            message: message.to_string(),
+        }
+    }
+
+    pub fn colorized(&mut self) -> String {
+        match self.colorized {
+            Some(ref s) => s.clone(),
+            None => {
+                let level_string = self
+                    .level_color
+                    .colorize(&self.level_string);
+                self.colorized = Some(
+                    format!("{}{} {}", self.prefix, level_string, self.message)
+                );
+
+                self.colorized.clone().unwrap()
+            }
+        }
+    }
+
+    pub fn non_colorized(&mut self) -> String {
+        match self.non_colorized {
+            Some(ref s) => s.clone(),
+            None => {
+                self.non_colorized = Some(
+                    format!("{}{} {}", self.prefix, self.level_string, self.message)
+                );
+
+                self.non_colorized.clone().unwrap()
+            }
+        }
+    }
+
+    pub fn formatted(&mut self, colorized: bool) -> String {
+        if colorized {
+            self.colorized()
+        } else {
+            self.non_colorized()
+        }
+    }
+}

--- a/src/log_message.rs
+++ b/src/log_message.rs
@@ -22,9 +22,9 @@ impl LogMessage {
             colorized: None,
             non_colorized: None,
             prefix: prefix.to_string(),
-            level_string:  format!("[{}]", level),
+            level_string: format!("[{}]", level),
             level_color: level.get_color(),
-            message: message.to_string(),
+            message: message.to_string()
         }
     }
 
@@ -32,12 +32,11 @@ impl LogMessage {
         match self.colorized {
             Some(ref s) => s.clone(),
             None => {
-                let level_string = self
-                    .level_color
-                    .colorize(&self.level_string);
-                self.colorized = Some(
-                    format!("{}{} {}\n", self.prefix, level_string, self.message)
-                );
+                let level_string = self.level_color.colorize(&self.level_string);
+                self.colorized = Some(format!(
+                    "{}{} {}\n",
+                    self.prefix, level_string, self.message
+                ));
 
                 self.colorized.clone().unwrap()
             }
@@ -48,9 +47,10 @@ impl LogMessage {
         match self.non_colorized {
             Some(ref s) => s.clone(),
             None => {
-                self.non_colorized = Some(
-                    format!("{}{} {}\n", self.prefix, self.level_string, self.message)
-                );
+                self.non_colorized = Some(format!(
+                    "{}{} {}\n",
+                    self.prefix, self.level_string, self.message
+                ));
 
                 self.non_colorized.clone().unwrap()
             }

--- a/src/log_message.rs
+++ b/src/log_message.rs
@@ -36,7 +36,7 @@ impl LogMessage {
                     .level_color
                     .colorize(&self.level_string);
                 self.colorized = Some(
-                    format!("{}{} {}", self.prefix, level_string, self.message)
+                    format!("{}{} {}\n", self.prefix, level_string, self.message)
                 );
 
                 self.colorized.clone().unwrap()
@@ -49,7 +49,7 @@ impl LogMessage {
             Some(ref s) => s.clone(),
             None => {
                 self.non_colorized = Some(
-                    format!("{}{} {}", self.prefix, self.level_string, self.message)
+                    format!("{}{} {}\n", self.prefix, self.level_string, self.message)
                 );
 
                 self.non_colorized.clone().unwrap()

--- a/src/log_message/tests.rs
+++ b/src/log_message/tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test]
+fn test_log_message_new_has_no_cache() {
+    let log_message = LogMessage::new("[wow]", "test", Level::Info);
+    assert_eq!(log_message.colorized, None);
+    assert_eq!(log_message.non_colorized, None);
+}
+
+#[test]
+fn test_log_message_should_create_cache_and_use_it() {
+    let mut log_message = LogMessage::new("[wow]", "test", Level::Info);
+    log_message.colorized();
+    assert!(log_message.colorized.is_some());
+    assert!(log_message.non_colorized.is_none());
+    log_message.non_colorized();
+    assert!(log_message.colorized.is_some());
+    assert!(log_message.non_colorized.is_some());
+    assert_ne!(log_message.colorized.as_ref().unwrap(), log_message.non_colorized.as_ref().unwrap());
+}
+
+#[test]
+fn test_formatted_should_return_proper_string() {
+    let mut log_message = LogMessage::new("[wow]", "test", Level::Info);
+    assert_eq!(log_message.formatted(false), "[wow][INFO] test\n".to_string());
+    let expected_colorized = format!(
+        "[wow]{} test\n",
+        Level::Info.get_color().colorize("[INFO]")
+    );
+    assert_eq!(log_message.formatted(true), expected_colorized);
+}


### PR DESCRIPTION
- added new log message struct to handle only formatting once when needed
- newline in log messages

closes #3 