### PR TITLE
Handling Existing Log Files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ lazy_static = "~1.4.0"
 chrono = "~0.4.19"
 serde = { version = "~1.0.135", features = ["derive"] }
 serde_yaml = "~0.8.23"
+
+[dev-dependencies]
+tempfile = "~3.3.0"

--- a/examples/full_usage/.gitignore
+++ b/examples/full_usage/.gitignore
@@ -1,1 +1,1 @@
-logs/
+logs/*.log

--- a/examples/full_usage/logs/README.md
+++ b/examples/full_usage/logs/README.md
@@ -1,0 +1,6 @@
+# Full Usage Example Logs Directory
+This directory is where the example should create a file `latest.log`.
+
+**DO NOT** remove  this readme from git. Having a file in this directory assures that
+this directory always exists with the example. If the directory doesn't exist when the
+example is run, then no file logging will happen.

--- a/examples/full_usage/main.rs
+++ b/examples/full_usage/main.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate pokey_logger;
 
-use pokey_logger::{LOGGER, Logger};
 use pokey_logger::existing_log_handler::ExistingLogHandler;
+use pokey_logger::{Logger, LOGGER};
 
 fn main() {
     // Load a configuration file

--- a/examples/full_usage/main.rs
+++ b/examples/full_usage/main.rs
@@ -17,6 +17,8 @@ fn main() {
     warn!("This is a warning");
     error!("This is an error");
 
+    // This is an example of creating a separate logger instance that also
+    // saves a new log every
     file_renaming();
 
     // This is important to ensure the log files are fully written before

--- a/examples/full_usage/main.rs
+++ b/examples/full_usage/main.rs
@@ -1,7 +1,8 @@
 #[macro_use]
 extern crate pokey_logger;
 
-use pokey_logger::LOGGER;
+use pokey_logger::{LOGGER, Logger};
+use pokey_logger::existing_log_handler::ExistingLogHandler;
 
 fn main() {
     // Load a configuration file
@@ -16,9 +17,23 @@ fn main() {
     warn!("This is a warning");
     error!("This is an error");
 
+    file_renaming();
+
     // This is important to ensure the log files are fully written before
     // shutting down.
     if let Err(e) = LOGGER.flush() {
         error!("Error flushing logs: {e:?}");
     }
+}
+
+/// An example of renaming the log file if it already exists before running.
+/// Each time it is run, the log file will be renamed with the datestamp, and
+/// then the actual log file will be overwritten.
+fn file_renaming() {
+    let logger = Logger::new();
+    logger.set_log_path("examples/full_usage/logs/rename_log.log");
+    logger.set_existing_log_handler(ExistingLogHandler::Rename);
+    logger.info("This is cool");
+    logger.flush().unwrap();
+    drop(logger);
 }

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -1,7 +1,7 @@
-use std::io;
-use std::fs;
-use serde::{Deserialize, Serialize};
 use crate::{ExistingLogHandler, Level};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io;
 
 // TODO: There should be different environments. All of these fields should be
 //       under the 'default' heading, then allow a set of environments to be
@@ -56,7 +56,8 @@ impl ConfigFile {
     /// structure of the file is incorrect.
     pub fn load(from_path: &str) -> Result<Self, ConfigFileLoadError> {
         let file = fs::read_to_string(from_path).map_err(ConfigFileLoadError::IoError)?;
-        let config: ConfigFile = serde_yaml::from_str(&file).map_err(ConfigFileLoadError::YamlError)?;
+        let config: ConfigFile =
+            serde_yaml::from_str(&file).map_err(ConfigFileLoadError::YamlError)?;
         Ok(config)
     }
 }

--- a/src/existing_log_handler.rs
+++ b/src/existing_log_handler.rs
@@ -1,3 +1,13 @@
+//! This module contains the different methods and handlers for what to do
+//! when a log file already exists.
+
+#[cfg(test)]
+mod tests;
+
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 /// The method of handling a pre-existing log file when starting a new session.
@@ -14,5 +24,92 @@ pub enum ExistingLogHandler {
 impl Default for ExistingLogHandler {
     fn default() -> Self {
         ExistingLogHandler::Append
+    }
+}
+
+#[derive(Debug)]
+pub enum ExistingLogHandlerOpenError {
+    /// Something went wrong when opening the existing log file or creating a new one.
+    Io(io::Error),
+    /// The path could not be used as a log file. This could because the path
+    /// is not a file.
+    InvalidPath
+}
+
+impl From<io::Error> for ExistingLogHandlerOpenError {
+    fn from(error: io::Error) -> Self {
+        ExistingLogHandlerOpenError::Io(error)
+    }
+}
+
+impl ExistingLogHandler {
+    pub fn open_file<P: AsRef<Path>>(&self, path: P) -> Result<File, ExistingLogHandlerOpenError> {
+        match self {
+            ExistingLogHandler::Append => if path.as_ref().exists(){
+                debug!("Appending to existing log file");
+                match File::options().append(true).open(path) {
+                    Ok(file) => Ok(file),
+                    Err(e) => Err(ExistingLogHandlerOpenError::Io(e))
+                }
+            } else {
+                debug!("Creating new log file");
+                match File::create(path) {
+                    Ok(file) => Ok(file),
+                    Err(e) => Err(ExistingLogHandlerOpenError::Io(e))
+                }
+            },
+            // TODO: Overwrite should handle new file creation.
+            ExistingLogHandler::Overwrite => match File::create(path) {
+                Ok(file) => Ok(file),
+                Err(e) => Err(ExistingLogHandlerOpenError::Io(e))
+            },
+            ExistingLogHandler::Rename => {
+                let path_buf = PathBuf::from(path.as_ref());
+                if path_buf.exists() {
+                    // Find the existing extension
+                    let existing_extension = match path_buf.extension() {
+                        Some(extension) => format!(".{}", extension.to_string_lossy()),
+                        None => String::new()
+                    };
+
+                    // Add the date before the extension
+                    let new_path = path_buf.with_extension(
+                        &format!("{}{}",
+                                 chrono::Local::now().format("%Y-%m-%d_%H-%M-%S"),
+                                 existing_extension));
+
+                    // Rename the file
+                    let mut new_file = match File::create(new_path.as_path()) {
+                        Ok(file) => file,
+                        Err(err) => return Err(ExistingLogHandlerOpenError::Io(err))
+                    };
+
+                    // Write the old file to the new file
+                    let old_file_content = match std::fs::read_to_string(path_buf.as_path()) {
+                        Ok(content) => content,
+                        Err(err) => return Err(ExistingLogHandlerOpenError::Io(err))
+                    };
+                    match new_file.write_all(old_file_content.as_bytes()) {
+                        Ok(_) => (),
+                        Err(err) => return Err(ExistingLogHandlerOpenError::Io(err))
+                    };
+
+                    let res = File::options()
+                        .create(true)
+                        .write(true)
+                        .open(path_buf.as_path());
+
+                    match res {
+                        Ok(file) => Ok(file),
+                        Err(err) => Err(ExistingLogHandlerOpenError::Io(err))
+                    }
+                } else {
+                    match File::create(path) {
+                        Ok(file) => Ok(file),
+                        Err(err) => Err(ExistingLogHandlerOpenError::Io(err))
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/existing_log_handler/tests.rs
+++ b/src/existing_log_handler/tests.rs
@@ -1,0 +1,88 @@
+use super::*;
+use tempfile::tempdir;
+
+#[test]
+fn test_append() -> Result<(), ExistingLogHandlerOpenError> {
+    let dir = tempdir()?;
+    assert!(dir.path().exists());
+
+    let log_path = dir.path().join("test.log");
+    debug!("log_path: {:?}", log_path);
+
+    let mut file = ExistingLogHandler::Append.open_file(log_path.as_path())?;
+    assert!(log_path.exists());
+    let mut expected_len = file.write(b"Hello, world!")?;
+    drop(file);
+
+    // Re-open the file and write another message
+    let mut file = ExistingLogHandler::Append.open_file(log_path.as_path())?;
+    expected_len += file.write(b"Goodbye, world!")?;
+    assert_ne!(0, expected_len);
+    drop(file);
+
+    // Check the file contents
+    let actual_len = std::fs::read_to_string(log_path)?.as_bytes().len();
+    assert_eq!(expected_len, actual_len);
+
+    Ok(())
+}
+
+#[test]
+fn test_overwrite() -> Result<(), ExistingLogHandlerOpenError> {
+    let dir = tempdir()?;
+    assert!(dir.path().exists());
+
+    let log_path = dir.path().join("test.log");
+    debug!("log_path: {:?}", log_path);
+
+    let mut file = ExistingLogHandler::Overwrite.open_file(log_path.as_path())?;
+    assert!(log_path.exists());
+    assert_ne!(0, file.write(b"Hello, world!")?);
+    drop(file);
+
+    // Re-open the file and write another message
+    let mut file = ExistingLogHandler::Overwrite.open_file(log_path.as_path())?;
+    let expected_len = file.write(b"Goodbye, world!")?;
+    assert_ne!(0, expected_len);
+    drop(file);
+
+    // Check the file contents
+    let actual_len = std::fs::read_to_string(log_path)?.as_bytes().len();
+    assert_eq!(expected_len, actual_len);
+
+    Ok(())
+}
+
+#[test]
+fn test_rename() -> Result<(), ExistingLogHandlerOpenError> {
+    let dir = tempdir()?;
+    assert!(dir.path().exists());
+
+    let log_path = dir.path().join("test.log");
+    debug!("log_path: {:?}", log_path);
+
+    let mut file = ExistingLogHandler::Rename.open_file(log_path.as_path())?;
+    assert!(log_path.exists());
+    assert_ne!(0, file.write(b"Hello, world!")?);
+    drop(file);
+
+    // Re-open the file and write another message
+    let mut file = ExistingLogHandler::Rename.open_file(log_path.as_path())?;
+    let expected_len = file.write(b"Goodbye, world!")?;
+    assert_ne!(0, expected_len);
+    drop(file);
+
+    // The file should not be overwritten and only have the new message
+    let actual_text = std::fs::read_to_string(log_path)?;
+    let actual_len = actual_text.as_bytes().len();
+    assert_eq!(expected_len, actual_len, "actual_text: {:?}", actual_text);
+
+    // There should be a new file with the original name with a date/time stamp
+    let dir_entries: Vec<String> = std::fs::read_dir(dir.path())?
+        .map(|entry| entry.unwrap().path().file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+    assert_eq!(2, dir_entries.len());
+    debug!("dir_entries: {:?}", dir_entries);
+
+    Ok(())
+}

--- a/src/existing_log_handler/tests.rs
+++ b/src/existing_log_handler/tests.rs
@@ -79,7 +79,15 @@ fn test_rename() -> Result<(), ExistingLogHandlerOpenError> {
 
     // There should be a new file with the original name with a date/time stamp
     let dir_entries: Vec<String> = std::fs::read_dir(dir.path())?
-        .map(|entry| entry.unwrap().path().file_name().unwrap().to_string_lossy().to_string())
+        .map(|entry| {
+            entry
+                .unwrap()
+                .path()
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        })
         .collect();
     assert_eq!(2, dir_entries.len());
     debug!("dir_entries: {:?}", dir_entries);

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,7 +1,7 @@
 use crate::TermColor::{self, *};
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::FromStr;
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize)]
 /// The log level.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,16 +61,17 @@ mod tests;
 #[macro_use]
 pub mod logging_macros;
 pub mod color;
-pub mod time;
 pub mod existing_log_handler;
+pub mod time;
 
 mod config_file;
 mod level; // not public because level is reexported
 mod log_message;
 
-pub use level::Level;
 pub use config_file::ConfigFileLoadError;
+pub use level::Level;
 
+use crate::existing_log_handler::ExistingLogHandler;
 use color::TermColor;
 use config_file::ConfigFile;
 use lazy_static::lazy_static;
@@ -80,7 +81,6 @@ use std::io::{prelude::*, BufWriter};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
-use crate::existing_log_handler::ExistingLogHandler;
 
 lazy_static!(
     /// The global logger.
@@ -292,8 +292,7 @@ impl Logger {
     fn set_log_writer_if_not_set(&self) {
         if !self.has_log_writer() {
             if let Some(path) = self.get_log_path() {
-                let file = match self.get_existing_log_handler()
-                    .open_file(&path) {
+                let file = match self.get_existing_log_handler().open_file(&path) {
                     Ok(f) => f,
                     Err(e) => {
                         error!("Could not open log file: {:?}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,7 +411,7 @@ impl Logger {
         self.set_log_file_color(config_file.file_color);
         self.set_existing_log_handler(config_file.existing_log_handler);
         if let Some(ref log_path) = config_file.log_file_path {
-            self.set_log_path(&log_path);
+            self.set_log_path(log_path);
         } else {
             self.remove_log_path();
         }
@@ -419,6 +419,12 @@ impl Logger {
         debug!("Config file loaded: {:?}", config_file);
 
         Ok(())
+    }
+}
+
+impl Default for Logger {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/log_message/tests.rs
+++ b/src/log_message/tests.rs
@@ -16,16 +16,19 @@ fn test_log_message_should_create_cache_and_use_it() {
     log_message.non_colorized();
     assert!(log_message.colorized.is_some());
     assert!(log_message.non_colorized.is_some());
-    assert_ne!(log_message.colorized.as_ref().unwrap(), log_message.non_colorized.as_ref().unwrap());
+    assert_ne!(
+        log_message.colorized.as_ref().unwrap(),
+        log_message.non_colorized.as_ref().unwrap()
+    );
 }
 
 #[test]
 fn test_formatted_should_return_proper_string() {
     let mut log_message = LogMessage::new("[wow]", "test", Level::Info);
-    assert_eq!(log_message.formatted(false), "[wow][INFO] test\n".to_string());
-    let expected_colorized = format!(
-        "[wow]{} test\n",
-        Level::Info.get_color().colorize("[INFO]")
+    assert_eq!(
+        log_message.formatted(false),
+        "[wow][INFO] test\n".to_string()
     );
+    let expected_colorized = format!("[wow]{} test\n", Level::Info.get_color().colorize("[INFO]"));
     assert_eq!(log_message.formatted(true), expected_colorized);
 }


### PR DESCRIPTION
- readme to keep full_usage example's log directory existing, and don't ignore the readme file
- existing log handler method implementations
- actually use the existing file handler
- clarifying comment on the full_usage example
